### PR TITLE
bugfix: fixed wrong calculation of hash length

### DIFF
--- a/src/hash_pbkdf2.php
+++ b/src/hash_pbkdf2.php
@@ -41,7 +41,7 @@ function hash_pbkdf2($algo, $password, $salt, $iterations, $length = 0, $raw_out
     }
 
     // Algorithm implementation
-    $hash_len = strlen(hash($algo, null, true));
+    $hash_len = strlen(hash($algo, null, $raw_output));
     if ($length == 0) {
         $length = $hash_len;
     }


### PR DESCRIPTION
This library is really cool, i discovered just one issue:

If you call `hash_pbkdf2` with default raw_output = false, than the resulting hash is not compatible to the hash created with the internal function hash_pbkdf2 in newer php, because you calculate the hash length always with raw_output = true. 

I stumbled over this issue after creating a bunch of hashes using php-5.6.1 and wanting to use those hashes on an older machine having your compat library installed.
